### PR TITLE
Bump aeson version bound

### DIFF
--- a/openapi-typed.cabal
+++ b/openapi-typed.cabal
@@ -37,7 +37,7 @@ library
   build-depends:
       base >=4.7 && <5
     , unordered-containers >= 0.2.10 && < 0.3
-    , aeson >= 1.4.7 && < 1.5
+    , aeson >= 1.4.7 && < 1.6
     , text >= 1.2.4 && < 1.3
     , vector >= 0.12.1 && < 0.13
   default-language: Haskell2010
@@ -53,7 +53,7 @@ test-suite openapi-typed-test
   build-depends:
       base >=4.7 && <5
     , openapi-typed
-    , aeson >= 1.4.7 && < 1.5
+    , aeson >= 1.4.7 && < 1.6
     , hspec >=2.7.1
     , unordered-containers >= 0.2.10 && < 0.3
     , optics-core >= 0.3


### PR DESCRIPTION
This change enables using openapi-typed with a more recent
aeson library.